### PR TITLE
Add extension badge + summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ This LocalStack extension generates a copy of the [Authress API](https://authres
     <a href="https://authress.io/community" alt="authress community">
       <img src="https://img.shields.io/badge/Community-Authress-fbaf0b.svg">
     </a>
+    <a href="https://app.localstack.cloud/extensions/remote?url=git+https://github.com/Authress/localstack-extension/#egg=localstack-extension-authress" alt="extensions installer">
+      <img src="https://localstack.cloud/gh/extension-badge.svg">
+    </a>
 </p>
 
 ---

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ name = localstack-extension-authress
 url = https://github.com/authress/authress-local
 author = Authress
 author_email = developers@authress.io
+summary = LocalStack Extension: Authress
 description = Add authentication, permissions, and access control to LocalStack
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8


### PR DESCRIPTION
Thanks @wparad for this amazing LocalStack extensions!

This PR adds the extension badge to the README, and further includes a summary field in the `setup.cfg` file which is used under the hood to display the name.

The installer, which is accessible via the badge/link, will only work once the PR is merged, since the summary field is missing.


A logo called `logo.png` with dimensions 128x128 would also be great to properly feature the extension in our web app!

Looking forward to get it featured on the webapp 🚀 